### PR TITLE
Disable Webrick's access log to make tests quieter

### DIFF
--- a/lib/dock_test/dsl.rb
+++ b/lib/dock_test/dsl.rb
@@ -13,7 +13,7 @@ module DockTest
 
         ARGV.clear # clear ARGV as it is used by Rack to configure server
 
-        server = WEBrick::HTTPServer.new(:Port => port).tap do |server|
+        server = WEBrick::HTTPServer.new(:Port => port, AccessLog: []).tap do |server|
           server.mount '/', Rack::Handler::WEBrick, Rack::Server.new.app
         end
         @server_thread = Thread.new { server.start }


### PR DESCRIPTION
Looking for feedback; maybe this should be an option we can add to the YAML file?
